### PR TITLE
feat: add methods shareFile and unshareFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/slack-wrap",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Wraps @slack/client to make it use destructured arguments",
   "engines": {
     "node": "^8.5.0"

--- a/src/slack/factory.js
+++ b/src/slack/factory.js
@@ -35,13 +35,13 @@ const getSlack = ({ accessToken, teamId }) => {
   return undefined
 }
 
-const addMethods = ({ accessToken, slack, slackUnwrapped, teamId, methods = false }) => {
+const addMethods = ({ accessToken, slack, teamId, methods = false }) => {
   const getTeamId = () => teamId
   const getAccessToken = () => accessToken
 
   return Object.assign(
     { getTeamId, getAccessToken },
-    methods ? mapValues(fn => fn(slack, slackUnwrapped))(methods) : {},
+    methods ? mapValues(fn => fn(slack))(methods) : {},
   )
 }
 
@@ -74,7 +74,6 @@ const factory = ({ accessToken, teamId, cachedPaths = false, methods = false } =
   const newMethods = addMethods({
     accessToken,
     slack: cached,
-    slackUnwrapped: unwrapped,
     methods: methods || require('./methods'),
     teamId,
   })

--- a/src/slack/factory.js
+++ b/src/slack/factory.js
@@ -60,7 +60,7 @@ const factory = ({ accessToken, teamId, cachedPaths = false, methods = false } =
   const existing = getSlack({ accessToken, teamId })
   if (existing) return existing
 
-  const unwrapped = (accessToken && teamId) ?
+  const unwrapped = accessToken ?
     new WebClient(accessToken) :
     new WebClient()
 

--- a/src/slack/factory.js
+++ b/src/slack/factory.js
@@ -35,13 +35,13 @@ const getSlack = ({ accessToken, teamId }) => {
   return undefined
 }
 
-const addMethods = ({ accessToken, slack, teamId, methods = false }) => {
+const addMethods = ({ accessToken, slack, slackUnwrapped, teamId, methods = false }) => {
   const getTeamId = () => teamId
   const getAccessToken = () => accessToken
 
   return Object.assign(
     { getTeamId, getAccessToken },
-    methods ? mapValues(fn => fn(slack))(methods) : {},
+    methods ? mapValues(fn => fn(slack, slackUnwrapped))(methods) : {},
   )
 }
 
@@ -74,6 +74,7 @@ const factory = ({ accessToken, teamId, cachedPaths = false, methods = false } =
   const newMethods = addMethods({
     accessToken,
     slack: cached,
+    slackUnwrapped: unwrapped,
     methods: methods || require('./methods'),
     teamId,
   })

--- a/src/slack/methods/files.js
+++ b/src/slack/methods/files.js
@@ -2,6 +2,8 @@
 
 /**
  * Shares a File to a Channel
+ * NB: THIS METHODS REQUIRES A BROWSER TOKEN.
+ *
  *
  * @method shareFile
  * @param {Object} slack - The wrapped slack
@@ -21,6 +23,7 @@ const shareFile = slack =>
 
 /**
  * Unshares a File to a Channel
+ * NB: THIS METHODS REQUIRES A BROWSER TOKEN.
  *
  * @method unshareFile
  * @param {Object} slack - The wrapped slack

--- a/src/slack/methods/files.js
+++ b/src/slack/methods/files.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Shares a File to a Channel
+ *
+ * @method shareFile
+ * @param {Object} slack - The wrapped slack
+ * @param {Object} slackUnwrapped - The unwrapped slack
+ * @param {String} options.channelId - The Slack Channel ID like 'C012345'
+ * @param {String} options.fileId - The Slack File ID like 'F012345'
+ * @return {Object} - A Slack Message object as returned by the API
+ */
+const shareFile = (slack, slackUnwrapped) =>
+  async ({ fileId, channelId }) =>
+    slackUnwrapped._makeAPICall('files.share', {
+      file: fileId,
+      channel: channelId,
+    })
+
+/**
+ * Unshares a File to a Channel
+ *
+ * @method unshareFile
+ * @param {Object} slack - The wrapped slack
+ * @param {Object} slackUnwrapped - The unwrapped slack
+ * @param {String} options.channelId - The Slack Channel ID like 'C012345'
+ * @param {String} options.fileId - The Slack File ID like 'F012345'
+ * @return {Object} - A Slack Message object as returned by the API
+ */
+const unshareFile = (slack, slackUnwrapped) =>
+  async ({ fileId, channelId }) =>
+    slackUnwrapped._makeAPICall('files.unshare', {
+      file: fileId,
+      channel: channelId,
+    })
+
+module.exports = {
+  shareFile,
+  unshareFile,
+}

--- a/src/slack/methods/files.js
+++ b/src/slack/methods/files.js
@@ -5,16 +5,18 @@
  *
  * @method shareFile
  * @param {Object} slack - The wrapped slack
- * @param {Object} slackUnwrapped - The unwrapped slack
  * @param {String} options.channelId - The Slack Channel ID like 'C012345'
  * @param {String} options.fileId - The Slack File ID like 'F012345'
  * @return {Object} - A Slack Message object as returned by the API
  */
-const shareFile = (slack, slackUnwrapped) =>
+const shareFile = slack =>
   async ({ fileId, channelId }) =>
-    slackUnwrapped._makeAPICall('files.share', {
-      file: fileId,
-      channel: channelId,
+    slack._makeAPICall({
+      endpoint: 'files.share',
+      apiArgs: {
+        file: fileId,
+        channel: channelId,
+      },
     })
 
 /**
@@ -22,16 +24,18 @@ const shareFile = (slack, slackUnwrapped) =>
  *
  * @method unshareFile
  * @param {Object} slack - The wrapped slack
- * @param {Object} slackUnwrapped - The unwrapped slack
  * @param {String} options.channelId - The Slack Channel ID like 'C012345'
  * @param {String} options.fileId - The Slack File ID like 'F012345'
  * @return {Object} - A Slack Message object as returned by the API
  */
-const unshareFile = (slack, slackUnwrapped) =>
+const unshareFile = slack =>
   async ({ fileId, channelId }) =>
-    slackUnwrapped._makeAPICall('files.unshare', {
-      file: fileId,
-      channel: channelId,
+    slack._makeAPICall({
+      endpoint: 'files.unshare',
+      apiArgs: {
+        file: fileId,
+        channel: channelId,
+      },
     })
 
 module.exports = {

--- a/src/slack/methods/index.js
+++ b/src/slack/methods/index.js
@@ -6,7 +6,9 @@
  */
 
 const message = require('./message')
+const files = require('./files')
 
 module.exports = {
   ...message,
+  ...files,
 }


### PR DESCRIPTION
I would love for it to be `slack.files.share()` instead of `slack.shareFile()`
but I don't know how to do it.
Got bitten too many times by meta-programming.
Please change it if you find a reasonable way to do it.

Thanks!